### PR TITLE
Add HLN-inspired React frontend, Next.js backoffice, and article APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+# HLN-inspired News Platform
+
+This repository contains a two-app workspace:
+
+- `frontend`: Public news website built with **React + Tailwind CSS**.
+- `backend`: **Next.js** backend that serves article APIs and a backoffice interface.
+
+## Features
+
+### Public frontend
+- HLN-inspired visual layout (red header, featured story, section blocks).
+- Fetches articles from backend API.
+- Groups stories by section (`Nieuws`, `Sport`, `Showbizz`, `Tech`).
+
+### Backoffice (Next.js)
+- Read current articles.
+- Add an article from a form.
+- Delete articles.
+- Data persisted in `backend/data/articles.json`.
+
+## Project structure
+
+```
+.
+├── backend
+│   ├── app
+│   │   ├── api/articles
+│   │   └── backoffice
+│   ├── data/articles.json
+│   └── lib
+└── frontend
+    └── src
+```
+
+## Getting started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start backend (port `3000`):
+   ```bash
+   npm run dev:backend
+   ```
+3. Start frontend (port `5173`):
+   ```bash
+   npm run dev:frontend
+   ```
+
+The frontend uses `http://localhost:3000` by default. Override via `frontend/.env`:
+
+```bash
+VITE_API_URL=http://localhost:3000
+```
+
+## Testing
+
+Run all unit tests:
+
+```bash
+npm test
+```
+
+### Covered functionality
+- Frontend data grouping utility (`groupBySection`).
+- Backend article input validation (`articleSchema`).
+
+## Maintainability notes
+
+- Types are centralized in `frontend/src/types.ts` and `backend/lib/types.ts`.
+- Validation is centralized in `backend/lib/validation.ts`.
+- File-based repository logic is isolated in `backend/lib/article-repository.ts`.
+- Presentation components are kept small (`NewsCard`) and composed in `App.tsx`.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,25 @@ This repository contains a two-app workspace:
 - `frontend`: Public news website built with **React + Tailwind CSS**.
 - `backend`: **Next.js** backend that serves article APIs and a backoffice interface.
 
+## What was improved
+
+- Reworked the public UI to much more closely follow the provided HLN-like layout:
+  - utility top bar
+  - bold red primary navigation
+  - secondary category bar
+  - large promotional strip
+  - three-column main content area (lead story, side stories, "Net Binnen" updates)
+- Kept components small and maintainable (`Header`, `HeroBanner`, `HomepageContent`).
+- Added layout-specific frontend utilities with dedicated unit tests.
+- Expanded backend unit test coverage with CRUD tests for repository functionality.
+
 ## Features
 
 ### Public frontend
-- HLN-inspired visual layout (red header, featured story, section blocks).
+- HLN-inspired visual structure and color palette.
 - Fetches articles from backend API.
-- Groups stories by section (`Nieuws`, `Sport`, `Showbizz`, `Tech`).
+- Computes homepage layout buckets (`featured`, `secondaryStories`, `liveUpdates`).
+- Formats live update timestamps.
 
 ### Backoffice (Next.js)
 - Read current articles.
@@ -27,7 +40,8 @@ This repository contains a two-app workspace:
 │   │   ├── api/articles
 │   │   └── backoffice
 │   ├── data/articles.json
-│   └── lib
+│   ├── lib
+│   └── __tests__
 └── frontend
     └── src
 ```
@@ -61,13 +75,18 @@ Run all unit tests:
 npm test
 ```
 
-### Covered functionality
-- Frontend data grouping utility (`groupBySection`).
-- Backend article input validation (`articleSchema`).
+### Frontend tests
+- `groupBySection` behavior.
+- homepage layout composition (`buildHomepageLayout`).
+- time label formatting (`toTimeLabel`).
+
+### Backend tests
+- schema validation (`articleSchema`).
+- repository CRUD (`listArticles`, `createArticle`, `updateArticle`, `removeArticle`).
 
 ## Maintainability notes
 
 - Types are centralized in `frontend/src/types.ts` and `backend/lib/types.ts`.
 - Validation is centralized in `backend/lib/validation.ts`.
 - File-based repository logic is isolated in `backend/lib/article-repository.ts`.
-- Presentation components are kept small (`NewsCard`) and composed in `App.tsx`.
+- Frontend page composition is split into focused components.

--- a/backend/__tests__/article-repository.test.ts
+++ b/backend/__tests__/article-repository.test.ts
@@ -1,0 +1,65 @@
+import { mkdtemp, readFile, writeFile } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createArticle, listArticles, removeArticle, updateArticle } from '../lib/article-repository';
+
+const seed = [
+  {
+    id: 'a1',
+    title: 'Seed title one',
+    section: 'Nieuws',
+    summary: 'Seed summary long enough',
+    imageUrl: 'https://example.com/seed.jpg',
+    featured: true,
+    publishedAt: '2025-01-01T00:00:00.000Z'
+  }
+];
+
+const payload = {
+  title: 'Created title from repository',
+  section: 'Sport' as const,
+  summary: 'Created summary is definitely long enough',
+  imageUrl: 'https://example.com/created.jpg',
+  featured: false,
+  publishedAt: '2025-01-01T10:00:00.000Z'
+};
+
+let testFile = '';
+
+beforeEach(async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'articles-test-'));
+  testFile = path.join(dir, 'articles.json');
+  await writeFile(testFile, JSON.stringify(seed, null, 2));
+  process.env.ARTICLES_FILE_PATH = testFile;
+});
+
+describe('article-repository', () => {
+  it('lists articles', async () => {
+    const items = await listArticles();
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe('a1');
+  });
+
+  it('creates a new article', async () => {
+    const created = await createArticle(payload);
+    expect(created.title).toBe(payload.title);
+
+    const saved = JSON.parse(await readFile(testFile, 'utf8')) as Array<{ id: string }>;
+    expect(saved).toHaveLength(2);
+    expect(saved[0].id).toBe(created.id);
+  });
+
+  it('updates an existing article', async () => {
+    const updated = await updateArticle('a1', { ...payload, title: 'Updated title' });
+    expect(updated?.title).toBe('Updated title');
+  });
+
+  it('removes an article', async () => {
+    const removed = await removeArticle('a1');
+    expect(removed).toBe(true);
+
+    const saved = JSON.parse(await readFile(testFile, 'utf8')) as Array<{ id: string }>;
+    expect(saved).toHaveLength(0);
+  });
+});

--- a/backend/__tests__/validation.test.ts
+++ b/backend/__tests__/validation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { articleSchema } from '../lib/validation';
+
+describe('articleSchema', () => {
+  it('accepts a valid payload', () => {
+    const result = articleSchema.safeParse({
+      title: 'Breaking update from Brussels',
+      section: 'Nieuws',
+      summary: 'This payload has enough text to be valid.',
+      imageUrl: 'https://example.com/image.jpg',
+      featured: true,
+      publishedAt: '2025-01-01T00:00:00.000Z'
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an invalid payload', () => {
+    const result = articleSchema.safeParse({
+      title: 'Bad',
+      section: 'Invalid',
+      summary: 'short',
+      imageUrl: 'not-an-url',
+      featured: true,
+      publishedAt: 'invalid-date'
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/app/api/articles/[id]/route.ts
+++ b/backend/app/api/articles/[id]/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { removeArticle, updateArticle } from '../../../../lib/article-repository';
+import { articleSchema } from '../../../../lib/validation';
+
+export async function PUT(request: Request, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const payload = await request.json();
+  const parsed = articleSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return NextResponse.json({ errors: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const updated = await updateArticle(id, parsed.data);
+
+  if (!updated) {
+    return NextResponse.json({ message: 'Article not found' }, { status: 404 });
+  }
+
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(_: Request, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const removed = await removeArticle(id);
+
+  if (!removed) {
+    return NextResponse.json({ message: 'Article not found' }, { status: 404 });
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/backend/app/api/articles/route.ts
+++ b/backend/app/api/articles/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { createArticle, listArticles } from '../../../lib/article-repository';
+import { articleSchema } from '../../../lib/validation';
+
+export async function GET() {
+  const articles = await listArticles();
+  return NextResponse.json(articles);
+}
+
+export async function POST(request: Request) {
+  const payload = await request.json();
+  const parsed = articleSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return NextResponse.json({ errors: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const created = await createArticle(parsed.data);
+  return NextResponse.json(created, { status: 201 });
+}

--- a/backend/app/backoffice/page.tsx
+++ b/backend/app/backoffice/page.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { FormEvent, useEffect, useState } from 'react';
+
+type Section = 'Nieuws' | 'Sport' | 'Showbizz' | 'Tech';
+
+interface Article {
+  id: string;
+  title: string;
+  section: Section;
+  summary: string;
+  imageUrl: string;
+  featured: boolean;
+  publishedAt: string;
+}
+
+const emptyForm = {
+  title: '',
+  section: 'Nieuws' as Section,
+  summary: '',
+  imageUrl: 'https://images.unsplash.com/photo-1495020689067-958852a7765e?auto=format&fit=crop&w=1200&q=80',
+  featured: false,
+  publishedAt: new Date().toISOString()
+};
+
+const BackofficePage = () => {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [form, setForm] = useState(emptyForm);
+
+  const refresh = async () => {
+    const response = await fetch('/api/articles');
+    setArticles(await response.json());
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+
+    await fetch('/api/articles', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    });
+
+    setForm(emptyForm);
+    await refresh();
+  };
+
+  const remove = async (id: string) => {
+    await fetch(`/api/articles/${id}`, { method: 'DELETE' });
+    await refresh();
+  };
+
+  return (
+    <main className="container">
+      <h1>Backoffice</h1>
+      <p>Create and remove homepage stories.</p>
+
+      <form onSubmit={submit} className="card">
+        <input
+          value={form.title}
+          onChange={(event) => setForm({ ...form, title: event.target.value })}
+          placeholder="Headline"
+          required
+        />
+        <textarea
+          value={form.summary}
+          onChange={(event) => setForm({ ...form, summary: event.target.value })}
+          placeholder="Summary"
+          required
+        />
+        <select
+          value={form.section}
+          onChange={(event) => setForm({ ...form, section: event.target.value as Section })}
+        >
+          <option>Nieuws</option>
+          <option>Sport</option>
+          <option>Showbizz</option>
+          <option>Tech</option>
+        </select>
+        <label>
+          <input
+            type="checkbox"
+            checked={form.featured}
+            onChange={(event) => setForm({ ...form, featured: event.target.checked })}
+          />
+          Featured
+        </label>
+        <button type="submit">Save article</button>
+      </form>
+
+      <section>
+        <h2>Current articles</h2>
+        <ul>
+          {articles.map((article) => (
+            <li key={article.id} className="card list-item">
+              <div>
+                <strong>{article.title}</strong>
+                <p>{article.section}</p>
+              </div>
+              <button type="button" onClick={() => remove(article.id)}>
+                Delete
+              </button>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+};
+
+export default BackofficePage;

--- a/backend/app/globals.css
+++ b/backend/app/globals.css
@@ -1,0 +1,46 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, Arial, sans-serif;
+  background: #f4f4f4;
+  color: #111;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.card {
+  background: white;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+input,
+textarea,
+select,
+button {
+  width: 100%;
+  padding: 0.6rem;
+  margin: 0.4rem 0;
+}
+
+button {
+  background: #d8001d;
+  color: white;
+  border: none;
+  border-radius: 0.4rem;
+  cursor: pointer;
+}

--- a/backend/app/layout.tsx
+++ b/backend/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+const RootLayout = ({ children }: { children: ReactNode }) => (
+  <html lang="en">
+    <body>{children}</body>
+  </html>
+);
+
+export default RootLayout;

--- a/backend/app/page.tsx
+++ b/backend/app/page.tsx
@@ -1,0 +1,11 @@
+const HomePage = () => (
+  <main style={{ fontFamily: 'sans-serif', padding: 24 }}>
+    <h1>Backend API & Backoffice</h1>
+    <p>Use the React frontend at port 5173 for the public site.</p>
+    <p>
+      Backoffice lives at <a href="/backoffice">/backoffice</a>.
+    </p>
+  </main>
+);
+
+export default HomePage;

--- a/backend/data/articles.json
+++ b/backend/data/articles.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "seed-1",
+    "title": "Brussels launches major mobility plan to reduce downtown traffic",
+    "section": "Nieuws",
+    "summary": "City leaders introduced a phased plan with extra bike lanes and revised bus routes.",
+    "imageUrl": "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3?auto=format&fit=crop&w=1200&q=80",
+    "featured": true,
+    "publishedAt": "2025-01-10T08:00:00.000Z"
+  },
+  {
+    "id": "seed-2",
+    "title": "Club secures dramatic late victory in title race",
+    "section": "Sport",
+    "summary": "A stoppage-time goal keeps the championship battle open with two rounds left.",
+    "imageUrl": "https://images.unsplash.com/photo-1431324155629-1a6deb1dec8d?auto=format&fit=crop&w=1200&q=80",
+    "featured": false,
+    "publishedAt": "2025-01-10T09:30:00.000Z"
+  },
+  {
+    "id": "seed-3",
+    "title": "Popular TV host announces surprise prime-time return",
+    "section": "Showbizz",
+    "summary": "The presenter will host a new weekly format after a two-year break.",
+    "imageUrl": "https://images.unsplash.com/photo-1522869635100-9f4c5e86aa37?auto=format&fit=crop&w=1200&q=80",
+    "featured": false,
+    "publishedAt": "2025-01-10T10:00:00.000Z"
+  },
+  {
+    "id": "seed-4",
+    "title": "Belgian startup unveils AI tool for local retailers",
+    "section": "Tech",
+    "summary": "The platform helps shop owners predict demand and personalize promotions.",
+    "imageUrl": "https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=1200&q=80",
+    "featured": false,
+    "publishedAt": "2025-01-10T11:15:00.000Z"
+  }
+]

--- a/backend/lib/article-repository.ts
+++ b/backend/lib/article-repository.ts
@@ -1,0 +1,56 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import type { Article } from './types';
+import type { ArticleInput } from './validation';
+
+const filePath = path.join(process.cwd(), 'data', 'articles.json');
+
+const readAll = async (): Promise<Article[]> => {
+  const file = await fs.readFile(filePath, 'utf-8');
+  return JSON.parse(file) as Article[];
+};
+
+const writeAll = async (articles: Article[]) => {
+  await fs.writeFile(filePath, JSON.stringify(articles, null, 2));
+};
+
+export const listArticles = async () => readAll();
+
+export const createArticle = async (input: ArticleInput) => {
+  const existing = await readAll();
+  const created: Article = {
+    id: crypto.randomUUID(),
+    ...input
+  };
+
+  const updated = [created, ...existing];
+  await writeAll(updated);
+  return created;
+};
+
+export const updateArticle = async (id: string, input: ArticleInput) => {
+  const existing = await readAll();
+  const index = existing.findIndex((article) => article.id === id);
+
+  if (index === -1) {
+    return null;
+  }
+
+  const updatedArticle: Article = { id, ...input };
+  existing[index] = updatedArticle;
+  await writeAll(existing);
+
+  return updatedArticle;
+};
+
+export const removeArticle = async (id: string) => {
+  const existing = await readAll();
+  const next = existing.filter((article) => article.id !== id);
+
+  if (next.length === existing.length) {
+    return false;
+  }
+
+  await writeAll(next);
+  return true;
+};

--- a/backend/lib/article-repository.ts
+++ b/backend/lib/article-repository.ts
@@ -3,15 +3,16 @@ import path from 'path';
 import type { Article } from './types';
 import type { ArticleInput } from './validation';
 
-const filePath = path.join(process.cwd(), 'data', 'articles.json');
+const resolveFilePath = () =>
+  process.env.ARTICLES_FILE_PATH ?? path.join(process.cwd(), 'data', 'articles.json');
 
 const readAll = async (): Promise<Article[]> => {
-  const file = await fs.readFile(filePath, 'utf-8');
+  const file = await fs.readFile(resolveFilePath(), 'utf-8');
   return JSON.parse(file) as Article[];
 };
 
 const writeAll = async (articles: Article[]) => {
-  await fs.writeFile(filePath, JSON.stringify(articles, null, 2));
+  await fs.writeFile(resolveFilePath(), JSON.stringify(articles, null, 2));
 };
 
 export const listArticles = async () => readAll();

--- a/backend/lib/types.ts
+++ b/backend/lib/types.ts
@@ -1,0 +1,11 @@
+export type Section = 'Nieuws' | 'Sport' | 'Showbizz' | 'Tech';
+
+export interface Article {
+  id: string;
+  title: string;
+  section: Section;
+  summary: string;
+  imageUrl: string;
+  featured: boolean;
+  publishedAt: string;
+}

--- a/backend/lib/validation.ts
+++ b/backend/lib/validation.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const articleSchema = z.object({
+  title: z.string().min(5),
+  section: z.enum(['Nieuws', 'Sport', 'Showbizz', 'Tech']),
+  summary: z.string().min(10),
+  imageUrl: z.string().url(),
+  featured: z.boolean().default(false),
+  publishedAt: z.string().datetime()
+});
+
+export type ArticleInput = z.infer<typeof articleSchema>;

--- a/backend/next-env.d.ts
+++ b/backend/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/backend/next.config.ts
+++ b/backend/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "backend",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "next": "^15.1.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.7",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  }
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  }
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HLN Inspired Newsroom</title>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "vitest run",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.5.1",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.7.3",
+    "vite": "^6.0.11",
+    "vitest": "^3.0.5",
+    "jsdom": "^26.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useMemo, useState } from 'react';
+import { NewsCard } from './components/NewsCard';
+import { fetchArticles, groupBySection } from './lib/articles';
+import type { Article } from './types';
+
+const App = () => {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setArticles(await fetchArticles());
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unknown error while loading news.');
+      }
+    };
+
+    void load();
+  }, []);
+
+  const featured = useMemo(() => articles.find((article) => article.featured), [articles]);
+  const grouped = useMemo(() => groupBySection(articles), [articles]);
+
+  return (
+    <div className="min-h-screen bg-gray-100 text-gray-900">
+      <header className="bg-brand text-white shadow-lg">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
+          <h1 className="text-3xl font-black tracking-tight">HLN Clone</h1>
+          <nav className="flex gap-4 text-sm font-semibold uppercase">
+            <a href="#Nieuws">Nieuws</a>
+            <a href="#Sport">Sport</a>
+            <a href="#Showbizz">Showbizz</a>
+            <a href="#Tech">Tech</a>
+          </nav>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-6xl space-y-8 px-4 py-6">
+        {error ? <p className="rounded-md bg-red-100 p-4 text-red-700">{error}</p> : null}
+
+        {featured ? (
+          <section className="overflow-hidden rounded-xl bg-white shadow-md">
+            <img src={featured.imageUrl} alt={featured.title} className="h-80 w-full object-cover" />
+            <div className="space-y-4 p-6">
+              <span className="text-sm font-bold uppercase text-brand">Top story</span>
+              <h2 className="text-3xl font-extrabold">{featured.title}</h2>
+              <p className="text-gray-700">{featured.summary}</p>
+            </div>
+          </section>
+        ) : null}
+
+        {Object.entries(grouped).map(([section, sectionArticles]) => (
+          <section key={section} id={section} className="space-y-4">
+            <h2 className="border-l-4 border-brand pl-3 text-2xl font-bold">{section}</h2>
+            <div className="grid gap-4 md:grid-cols-3">
+              {sectionArticles.map((article) => (
+                <NewsCard key={article.id} article={article} />
+              ))}
+            </div>
+          </section>
+        ))}
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
-import { NewsCard } from './components/NewsCard';
+import { Header } from './components/Header';
+import { HeroBanner } from './components/HeroBanner';
+import { HomepageContent } from './components/HomepageContent';
 import { fetchArticles, groupBySection } from './lib/articles';
+import { buildHomepageLayout } from './lib/layout';
 import type { Article } from './types';
 
 const App = () => {
@@ -19,48 +22,39 @@ const App = () => {
     void load();
   }, []);
 
-  const featured = useMemo(() => articles.find((article) => article.featured), [articles]);
+  const layout = useMemo(() => buildHomepageLayout(articles), [articles]);
   const grouped = useMemo(() => groupBySection(articles), [articles]);
 
   return (
-    <div className="min-h-screen bg-gray-100 text-gray-900">
-      <header className="bg-brand text-white shadow-lg">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
-          <h1 className="text-3xl font-black tracking-tight">HLN Clone</h1>
-          <nav className="flex gap-4 text-sm font-semibold uppercase">
-            <a href="#Nieuws">Nieuws</a>
-            <a href="#Sport">Sport</a>
-            <a href="#Showbizz">Showbizz</a>
-            <a href="#Tech">Tech</a>
-          </nav>
+    <div className="min-h-screen bg-[#ececec] text-gray-900">
+      <Header />
+      <HeroBanner />
+
+      {error ? <p className="mx-auto mt-4 max-w-[1280px] rounded-md bg-red-100 p-4 text-red-700">{error}</p> : null}
+
+      <HomepageContent
+        featured={layout.featured}
+        secondaryStories={layout.secondaryStories}
+        liveUpdates={layout.liveUpdates}
+      />
+
+      <section className="mx-auto mb-10 max-w-[1280px] px-4">
+        <h2 className="mb-4 inline-block bg-[#e30613] px-4 py-2 text-xl font-bold uppercase text-white">Meer nieuws</h2>
+        <div className="grid gap-4 md:grid-cols-4">
+          {Object.entries(grouped).map(([section, sectionArticles]) => (
+            <article key={section} className="rounded bg-white p-4 shadow-sm">
+              <h3 className="mb-3 text-lg font-bold text-[#e30613]">{section}</h3>
+              <ul className="space-y-2">
+                {sectionArticles.slice(0, 3).map((item) => (
+                  <li key={item.id} className="text-sm font-semibold text-blue-700">
+                    {item.title}
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
         </div>
-      </header>
-
-      <main className="mx-auto max-w-6xl space-y-8 px-4 py-6">
-        {error ? <p className="rounded-md bg-red-100 p-4 text-red-700">{error}</p> : null}
-
-        {featured ? (
-          <section className="overflow-hidden rounded-xl bg-white shadow-md">
-            <img src={featured.imageUrl} alt={featured.title} className="h-80 w-full object-cover" />
-            <div className="space-y-4 p-6">
-              <span className="text-sm font-bold uppercase text-brand">Top story</span>
-              <h2 className="text-3xl font-extrabold">{featured.title}</h2>
-              <p className="text-gray-700">{featured.summary}</p>
-            </div>
-          </section>
-        ) : null}
-
-        {Object.entries(grouped).map(([section, sectionArticles]) => (
-          <section key={section} id={section} className="space-y-4">
-            <h2 className="border-l-4 border-brand pl-3 text-2xl font-bold">{section}</h2>
-            <div className="grid gap-4 md:grid-cols-3">
-              {sectionArticles.map((article) => (
-                <NewsCard key={article.id} article={article} />
-              ))}
-            </div>
-          </section>
-        ))}
-      </main>
+      </section>
     </div>
   );
 };

--- a/frontend/src/__tests__/articles.test.ts
+++ b/frontend/src/__tests__/articles.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { groupBySection } from '../lib/articles';
+
+describe('groupBySection', () => {
+  it('groups articles by section', () => {
+    const grouped = groupBySection([
+      {
+        id: '1',
+        title: 'A',
+        section: 'Nieuws',
+        summary: 'summary',
+        imageUrl: 'image',
+        featured: false,
+        publishedAt: '2025-01-01'
+      },
+      {
+        id: '2',
+        title: 'B',
+        section: 'Sport',
+        summary: 'summary',
+        imageUrl: 'image',
+        featured: false,
+        publishedAt: '2025-01-02'
+      }
+    ]);
+
+    expect(grouped.Nieuws).toHaveLength(1);
+    expect(grouped.Sport).toHaveLength(1);
+  });
+});

--- a/frontend/src/__tests__/layout.test.ts
+++ b/frontend/src/__tests__/layout.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { buildHomepageLayout, toTimeLabel } from '../lib/layout';
+
+const articles = [
+  {
+    id: '1',
+    title: 'Feature',
+    section: 'Nieuws' as const,
+    summary: 'summary text long enough',
+    imageUrl: 'https://example.com/1.jpg',
+    featured: true,
+    publishedAt: '2025-01-01T09:10:00.000Z'
+  },
+  {
+    id: '2',
+    title: 'Second',
+    section: 'Sport' as const,
+    summary: 'summary text long enough',
+    imageUrl: 'https://example.com/2.jpg',
+    featured: false,
+    publishedAt: '2025-01-01T09:20:00.000Z'
+  },
+  {
+    id: '3',
+    title: 'Third',
+    section: 'Tech' as const,
+    summary: 'summary text long enough',
+    imageUrl: 'https://example.com/3.jpg',
+    featured: false,
+    publishedAt: '2025-01-01T09:30:00.000Z'
+  }
+];
+
+describe('buildHomepageLayout', () => {
+  it('returns featured, secondary, and live update buckets', () => {
+    const layout = buildHomepageLayout(articles);
+
+    expect(layout.featured?.id).toBe('1');
+    expect(layout.secondaryStories.map((story) => story.id)).toEqual(['2', '3']);
+    expect(layout.liveUpdates).toHaveLength(0);
+  });
+
+  it('falls back to first story when no item is featured', () => {
+    const withoutFeatured = articles.map((article) => ({ ...article, featured: false }));
+    const layout = buildHomepageLayout(withoutFeatured);
+
+    expect(layout.featured?.id).toBe('1');
+  });
+});
+
+describe('toTimeLabel', () => {
+  it('formats timestamp to HH:mm', () => {
+    expect(toTimeLabel('2025-01-01T09:07:00.000Z')).toMatch(/^\d{2}:\d{2}$/);
+  });
+});

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,48 @@
+const utilityLinks = ['Weer', 'TV-Gids', 'Meld Nieuws', 'Digitale Krant', 'Shop', 'Over Ons'];
+const primaryLinks = ['Nieuws', 'Sport', 'Showbizz', 'Nina', 'Regio', 'Kijk', 'Puzzel', 'Podcast'];
+const secondaryLinks = ['Opinie', 'Mijn Geld', 'VTM NIEUWS', 'Eten', 'Tech', 'Mobiliteit', 'Gezondheid', 'Woon'];
+
+export const Header = () => (
+  <header className="shadow-sm">
+    <div className="bg-white text-xs font-semibold text-blue-700">
+      <div className="mx-auto flex max-w-[1280px] items-center justify-between px-4 py-2">
+        <div className="flex flex-wrap gap-4">
+          {utilityLinks.map((link) => (
+            <a key={link} href="#" className="hover:underline">
+              {link}
+            </a>
+          ))}
+        </div>
+        <a href="#" className="hover:underline">
+          Klantenservice
+        </a>
+      </div>
+    </div>
+
+    <div className="bg-[#e30613] text-white">
+      <div className="mx-auto flex max-w-[1280px] items-center gap-6 px-4 py-3">
+        <div className="rounded-md bg-red-700 px-4 py-2 text-5xl font-black leading-none">HLN</div>
+        <nav
+          className="flex flex-wrap items-center gap-6 font-black uppercase"
+          style={{ fontFamily: 'Impact, Haettenschweiler, Arial Narrow Bold, sans-serif' }}
+        >
+          {primaryLinks.map((link) => (
+            <a key={link} href="#" className="text-4xl leading-none hover:opacity-80">
+              {link}
+            </a>
+          ))}
+        </nav>
+      </div>
+    </div>
+
+    <div className="border-b bg-white">
+      <div className="mx-auto flex max-w-[1280px] flex-wrap gap-5 px-4 py-2 text-base font-semibold">
+        {secondaryLinks.map((link) => (
+          <a key={link} href="#" className="hover:underline">
+            {link}
+          </a>
+        ))}
+      </div>
+    </div>
+  </header>
+);

--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -1,0 +1,21 @@
+export const HeroBanner = () => (
+  <section className="mx-auto mt-4 max-w-[1280px] px-4">
+    <div className="grid grid-cols-[160px_1fr_160px] gap-4 rounded-sm bg-[#efefef] p-4">
+      <div className="space-y-3 text-center">
+        <div className="rounded-full border border-gray-400 bg-white px-3 py-1 text-sm">PROEVERTJES</div>
+        <div className="rounded-full border border-gray-400 bg-white px-3 py-1 text-sm">KOOKDEMO'S</div>
+        <div className="rounded-full border border-gray-400 bg-white px-3 py-1 text-sm">DEMONSTRATIES</div>
+      </div>
+      <div className="rounded bg-[#f58220] p-6 text-white">
+        <p className="text-2xl font-bold uppercase">Dovy Keukenfestival</p>
+        <p className="mt-3 text-4xl font-black uppercase leading-tight">Dit weekend haal je het beursgevoel naar de toonzaal</p>
+        <button className="mt-4 rounded-full border-2 border-white px-6 py-2 text-lg font-semibold">MEER INFO</button>
+      </div>
+      <div className="space-y-3 text-center">
+        <div className="rounded-full border border-gray-400 bg-white px-3 py-1 text-sm">PROEVERTJES</div>
+        <div className="rounded-full border border-gray-400 bg-white px-3 py-1 text-sm">KOOKDEMO'S</div>
+        <div className="rounded-full border border-gray-400 bg-white px-3 py-1 text-sm">DEMONSTRATIES</div>
+      </div>
+    </div>
+  </section>
+);

--- a/frontend/src/components/HomepageContent.tsx
+++ b/frontend/src/components/HomepageContent.tsx
@@ -1,0 +1,53 @@
+import type { Article } from '../types';
+import { toTimeLabel } from '../lib/layout';
+
+interface HomepageContentProps {
+  featured: Article | null;
+  secondaryStories: Article[];
+  liveUpdates: Article[];
+}
+
+export const HomepageContent = ({ featured, secondaryStories, liveUpdates }: HomepageContentProps) => (
+  <main className="mx-auto mt-4 max-w-[1280px] px-4 pb-10">
+    <div className="grid grid-cols-12 gap-4">
+      <section className="col-span-12 overflow-hidden bg-black text-white md:col-span-6">
+        {featured ? (
+          <>
+            <img src={featured.imageUrl} alt={featured.title} className="h-[420px] w-full object-cover opacity-80" />
+            <div className="-mt-32 bg-gradient-to-t from-black px-6 pb-6 pt-20">
+              <p className="text-4xl font-extrabold leading-tight">{featured.title}</p>
+            </div>
+          </>
+        ) : null}
+      </section>
+
+      <section className="col-span-12 space-y-4 md:col-span-3">
+        {secondaryStories.map((article) => (
+          <article key={article.id} className="bg-white p-2">
+            <img src={article.imageUrl} alt={article.title} className="h-48 w-full object-cover" />
+            <h2 className="mt-3 text-3xl font-bold leading-tight text-blue-700">{article.title}</h2>
+          </article>
+        ))}
+      </section>
+
+      <aside className="col-span-12 bg-white md:col-span-3">
+        <div className="border border-gray-200 p-4">
+          <h2 className="text-2xl font-bold">Wil je elke dag de HLN nieuwsbrief?</h2>
+          <input className="mt-3 w-full rounded border px-3 py-2" placeholder="E-mail" />
+          <button className="mt-3 w-full rounded bg-[#e30613] py-2 font-semibold text-white">Verstuur</button>
+        </div>
+        <div className="mt-4 border-t">
+          <h3 className="inline-block bg-[#e30613] px-4 py-2 text-3xl font-black uppercase text-white">Net Binnen</h3>
+          <ul className="space-y-3 p-4">
+            {liveUpdates.map((article) => (
+              <li key={article.id}>
+                <p className="text-lg font-bold text-[#e30613]">{toTimeLabel(article.publishedAt)}</p>
+                <p className="text-2xl font-semibold leading-tight text-blue-700">{article.title}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </main>
+);

--- a/frontend/src/components/NewsCard.tsx
+++ b/frontend/src/components/NewsCard.tsx
@@ -1,0 +1,16 @@
+import type { Article } from '../types';
+
+interface NewsCardProps {
+  article: Article;
+}
+
+export const NewsCard = ({ article }: NewsCardProps) => (
+  <article className="overflow-hidden rounded-lg bg-white shadow-sm">
+    <img src={article.imageUrl} alt={article.title} className="h-40 w-full object-cover" />
+    <div className="space-y-2 p-4">
+      <span className="text-xs font-semibold uppercase tracking-wide text-brand">{article.section}</span>
+      <h3 className="text-lg font-semibold text-gray-900">{article.title}</h3>
+      <p className="text-sm text-gray-600">{article.summary}</p>
+    </div>
+  </article>
+);

--- a/frontend/src/lib/articles.ts
+++ b/frontend/src/lib/articles.ts
@@ -1,0 +1,22 @@
+import type { Article } from '../types';
+
+const API_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:3000';
+
+export const fetchArticles = async (): Promise<Article[]> => {
+  const response = await fetch(`${API_URL}/api/articles`, {
+    headers: { Accept: 'application/json' }
+  });
+
+  if (!response.ok) {
+    throw new Error('Unable to load articles from backend.');
+  }
+
+  return (await response.json()) as Article[];
+};
+
+export const groupBySection = (articles: Article[]): Record<string, Article[]> =>
+  articles.reduce<Record<string, Article[]>>((groups, article) => {
+    groups[article.section] = groups[article.section] ?? [];
+    groups[article.section].push(article);
+    return groups;
+  }, {});

--- a/frontend/src/lib/layout.ts
+++ b/frontend/src/lib/layout.ts
@@ -1,0 +1,23 @@
+import type { Article } from '../types';
+
+export interface HomepageLayout {
+  featured: Article | null;
+  secondaryStories: Article[];
+  liveUpdates: Article[];
+}
+
+export const buildHomepageLayout = (articles: Article[]): HomepageLayout => {
+  const featured = articles.find((article) => article.featured) ?? articles[0] ?? null;
+  const remaining = featured ? articles.filter((article) => article.id !== featured.id) : [];
+
+  return {
+    featured,
+    secondaryStories: remaining.slice(0, 2),
+    liveUpdates: remaining.slice(2, 7)
+  };
+};
+
+export const toTimeLabel = (iso: string): string => {
+  const date = new Date(iso);
+  return `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,11 @@
+export type Section = 'Nieuws' | 'Sport' | 'Showbizz' | 'Tech';
+
+export interface Article {
+  id: string;
+  title: string;
+  section: Section;
+  summary: string;
+  imageUrl: string;
+  featured: boolean;
+  publishedAt: string;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        brand: '#d8001d'
+      }
+    }
+  },
+  plugins: []
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/test-setup.ts'
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "hln-clone-workspace",
+  "private": true,
+  "workspaces": [
+    "frontend",
+    "backend"
+  ],
+  "scripts": {
+    "dev:frontend": "npm --workspace frontend run dev",
+    "dev:backend": "npm --workspace backend run dev",
+    "build": "npm run build --workspaces",
+    "test": "npm run test --workspaces"
+  }
+}


### PR DESCRIPTION
### Motivation
- Create an HLN-like news site with a modern stack: a React + Tailwind public frontend and a Next.js backend that includes a backoffice for content management.
- Provide a clear, maintainable implementation with types, validation, simple persistence, documentation and unit tests to make the project immediately usable and extensible.

### Description
- Added a workspace with `frontend` (React + Vite + Tailwind) and `backend` (Next.js) applications and root scripts for dev/build/test orchestration using workspaces.
- Implemented the public UI: `App.tsx` rendering a branded header, featured hero and section grids, reusable `NewsCard` component, `fetchArticles` API client and `groupBySection` utility, plus Tailwind config and styles.
- Implemented backend APIs and backoffice: Next.js API routes for `GET`/`POST` `/api/articles` and `PUT`/`DELETE` `/api/articles/[id]`, schema validation with `zod` in `backend/lib/validation.ts`, file-based repository in `backend/lib/article-repository.ts`, and a client-side backoffice page at `/backoffice` for creating/deleting articles.
- Added seed data in `backend/data/articles.json`, TypeScript types in both apps, unit tests (`frontend/src/__tests__/articles.test.ts` and `backend/__tests__/validation.test.ts`), and a `README.md` with setup and testing instructions.

### Testing
- Unit tests were added for frontend grouping (`groupBySection`) and backend validation (`articleSchema`) and are runnable via `vitest` in each package when dependencies are installed.
- Attempted automated install with `npm install` in this environment failed due to registry access returning `403 Forbidden`, so tests (`npm test` / `vitest`) could not be executed here.
- A browser screenshot attempt of the running frontend could not be performed because the frontend server could not be started without installing dependencies, yielding a network error during navigation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69935ea33940832c8eddf98a55a201af)